### PR TITLE
List chains refactor

### DIFF
--- a/src/TestchainService.js
+++ b/src/TestchainService.js
@@ -432,7 +432,9 @@ export default class TestchainService {
     // have clean_on_stop: false. Use only at initialize.
     return new Promise((resolve, reject) => {
       // TODO: check if api channel is connected first
-      this._apiChannel.push('list_chains', {}).receive('ok', ({ chains }) => {
+      this._apiChannel.push('list_chains', {}).receive('ok', data => {
+        console.log(data);
+        const { chains } = data;
         resolve(chains);
       });
       // TODO: error handling?

--- a/src/TestchainService.js
+++ b/src/TestchainService.js
@@ -431,22 +431,22 @@ export default class TestchainService {
     });
   }
 
-  async listChains() {
-    return await this._listChains();
-  }
+  // async listChains() {
+  //   return await this._listChains();
+  // }
 
-  _listChains() {
-    // this function will only respond with those chains which
-    // have clean_on_stop: false. Use only at initialize.
-    return new Promise((resolve, reject) => {
-      // TODO: check if api channel is connected first
-      this._apiChannel.push('list_chains', {}).receive('ok', data => {
-        const { chains } = data;
-        resolve(chains);
-      });
-      // TODO: error handling?
-    });
-  }
+  // _listChains() {
+  //   // this function will only respond with those chains which
+  //   // have clean_on_stop: false. Use only at initialize.
+  //   return new Promise((resolve, reject) => {
+  //     // TODO: check if api channel is connected first
+  //     this._apiChannel.push('list_chains', {}).receive('ok', data => {
+  //       const { chains } = data;
+  //       resolve(chains);
+  //     });
+  //     // TODO: error handling?
+  //   });
+  // }
 
   async removeAllChains() {
     for (let id of Object.keys(this._chainList)) {

--- a/src/TestchainService.js
+++ b/src/TestchainService.js
@@ -10,7 +10,7 @@ const logDelete = debug('log:delete');
 const API_CHANNEL = 'api';
 const API_URL = 'ws://127.1:4000/socket';
 const API_TIMEOUT = 5000;
-const HTTP_URL = 'http://localhost:4000/';
+const HTTP_URL = 'http://localhost:4000';
 
 export default class TestchainService {
   constructor() {
@@ -25,7 +25,7 @@ export default class TestchainService {
 
   async initialize() {
     await this.connectApp();
-    const chains = await this._listChains();
+    const chains = await this.fetchChains();
 
     for (let chain of chains) {
       const chainData = await this.fetchChain(chain.id);
@@ -43,12 +43,13 @@ export default class TestchainService {
         active: chain.status === 'active' ? true : false,
         eventRefs: {}
       };
-      const snapshots = await this.fetchSnapshots();
-      snapshots.map(snapshot => (this._snapshots[snapshot.id] = snapshot));
 
       await this._registerDefaultEventListeners(chain.id);
       await this._joinChain(chain.id);
     }
+
+    const snapshots = await this.fetchSnapshots();
+    snapshots.map(snapshot => (this._snapshots[snapshot.id] = snapshot));
   }
 
   /*
@@ -344,22 +345,6 @@ export default class TestchainService {
   getSnap(id) {
     return this._snapshots[id];
   }
-
-  // Use fetchSnapshots() instead, this doesn't seem to be working
-  // TODO: factor this out if we don't need it.
-  listSnapshots() {
-    const chain = 'ganache';
-    return new Promise((resolve, reject) => {
-      this._apiChannel
-        .push('list_snapshots', { chain })
-        .receive('ok', ({ snapshots }) => resolve(snapshots))
-        .receive('error', console.error)
-        .receive('timeout', () =>
-          console.log('Timeout loading list of snapshots')
-        );
-    });
-  }
-
   /*
    * fetchChain will send a get request to the server for a specific chain based on
    * the id parameter.
@@ -373,25 +358,7 @@ export default class TestchainService {
       const res = await fetch(`${HTTP_URL}/chain/${id}`);
       const obj = await res.json();
 
-      if (obj.status) {
-        if (await this.chainExists(id)) {
-          const { accounts, coinbase, rpc_url, ws_url } = this.getChain(id);
-          resolve({
-            details: {
-              accounts,
-              coinbase,
-              id,
-              rpc_url,
-              ws_url
-            },
-            status: 1
-          });
-        }
-
-        reject('Chain Does Not Exist');
-      } else {
-        resolve(obj);
-      }
+      obj.status === 0 ? resolve(obj) : reject('Chain Does Not Exist');
     });
   }
 
@@ -406,7 +373,7 @@ export default class TestchainService {
   fetchSnapshots() {
     const chainType = 'ganache';
     return new Promise(async (resolve, reject) => {
-      const res = await fetch(`${HTTP_URL}snapshots/${chainType}`);
+      const res = await fetch(`${HTTP_URL}/chain/snapshots/${chainType}`);
       const { list, status } = await res.json();
       status === 0 ? resolve(list) : reject('Error fetching snapshot');
     });
@@ -431,25 +398,10 @@ export default class TestchainService {
     });
   }
 
-  // async listChains() {
-  //   return await this._listChains();
-  // }
-
-  // _listChains() {
-  //   // this function will only respond with those chains which
-  //   // have clean_on_stop: false. Use only at initialize.
-  //   return new Promise((resolve, reject) => {
-  //     // TODO: check if api channel is connected first
-  //     this._apiChannel.push('list_chains', {}).receive('ok', data => {
-  //       const { chains } = data;
-  //       resolve(chains);
-  //     });
-  //     // TODO: error handling?
-  //   });
-  // }
-
   async removeAllChains() {
-    for (let id of Object.keys(this._chainList)) {
+    const chainList = await this.fetchChains();
+    for (const chain of chainList) {
+      const id = chain.id;
       if (this.isChainActive(id)) {
         await this.stopChain(id);
       }
@@ -491,7 +443,7 @@ export default class TestchainService {
   async chainExists(id) {
     if (this.isChainActive(id)) return true;
 
-    const chains = await this.listChains();
+    const chains = await this.fetchChains();
     for (let chain of chains) {
       if (chain.id === id) {
         return true;

--- a/src/TestchainService.js
+++ b/src/TestchainService.js
@@ -10,7 +10,7 @@ const logDelete = debug('log:delete');
 const API_CHANNEL = 'api';
 const API_URL = 'ws://127.1:4000/socket';
 const API_TIMEOUT = 5000;
-const HTTP_URL = 'http://localhost:4000/chain/';
+const HTTP_URL = 'http://localhost:4000/';
 
 export default class TestchainService {
   constructor() {
@@ -370,7 +370,7 @@ export default class TestchainService {
    */
   fetchChain(id) {
     return new Promise(async (resolve, reject) => {
-      const res = await fetch(`${HTTP_URL}${id}`);
+      const res = await fetch(`${HTTP_URL}/chain/${id}`);
       const obj = await res.json();
 
       if (obj.status) {
@@ -395,6 +395,14 @@ export default class TestchainService {
     });
   }
 
+  fetchChains() {
+    return new Promise(async (resolve, reject) => {
+      const res = await fetch(`${HTTP_URL}/chains`);
+      const { list } = await res.json();
+      resolve(list);
+    });
+  }
+
   fetchSnapshots() {
     const chainType = 'ganache';
     return new Promise(async (resolve, reject) => {
@@ -406,7 +414,7 @@ export default class TestchainService {
 
   fetchDelete(id) {
     return new Promise(async (resolve, reject) => {
-      const res = await fetch(`${HTTP_URL}${id}`, {
+      const res = await fetch(`${HTTP_URL}/chain/${id}`, {
         method: 'DELETE'
       });
       const msg = await res.json();
@@ -433,7 +441,6 @@ export default class TestchainService {
     return new Promise((resolve, reject) => {
       // TODO: check if api channel is connected first
       this._apiChannel.push('list_chains', {}).receive('ok', data => {
-        console.log(data);
         const { chains } = data;
         resolve(chains);
       });

--- a/test/TestChainService.test.js
+++ b/test/TestChainService.test.js
@@ -81,6 +81,23 @@ describe('chain behaviour', async () => {
     expect(Object.keys(chainList)[0]).toEqual(id);
   });
 
+  test.only('list_chain', async () => {
+    const { id: id1 } = await service.createChainInstance({ ...options });
+    const { id: id2 } = await service.createChainInstance({
+      ...options,
+      clean_on_stop: false
+    });
+    console.log(id1, id2);
+    const chain1 = service.getChainInfo(id1);
+    const chain2 = service.getChainInfo(id2);
+
+    const chainsList = await service.listChains();
+
+    log(chain1);
+    log(chain2);
+    log(chainsList);
+  });
+
   test('initialize should populate chainLists with correct data', async () => {
     const chains = await service.listChains();
     expect(chains.length).toEqual(0);

--- a/test/TestChainService.test.js
+++ b/test/TestChainService.test.js
@@ -91,11 +91,12 @@ describe('chain behaviour', async () => {
     const chain1 = service.getChainInfo(id1);
     const chain2 = service.getChainInfo(id2);
 
-    const chainsList = await service.listChains();
-
-    log(chain1);
-    log(chain2);
+    const chainsList = await service.fetchChains();
     log(chainsList);
+    await service.stopChain(id2);
+
+    const chainsList2 = await service.fetchChains();
+    log(chainsList2);
   });
 
   test('initialize should populate chainLists with correct data', async () => {

--- a/test/TestChainService.test.js
+++ b/test/TestChainService.test.js
@@ -81,26 +81,8 @@ describe('chain behaviour', async () => {
     expect(Object.keys(chainList)[0]).toEqual(id);
   });
 
-  test.only('list_chain', async () => {
-    const { id: id1 } = await service.createChainInstance({ ...options });
-    const { id: id2 } = await service.createChainInstance({
-      ...options,
-      clean_on_stop: false
-    });
-    console.log(id1, id2);
-    const chain1 = service.getChainInfo(id1);
-    const chain2 = service.getChainInfo(id2);
-
-    const chainsList = await service.fetchChains();
-    log(chainsList);
-    await service.stopChain(id2);
-
-    const chainsList2 = await service.fetchChains();
-    log(chainsList2);
-  });
-
   test('initialize should populate chainLists with correct data', async () => {
-    const chains = await service.listChains();
+    const chains = await service.fetchChains();
     expect(chains.length).toEqual(0);
     const { id } = await service.createChainInstance({
       ...options,
@@ -227,6 +209,16 @@ describe('chain removal', async () => {
     expect(await service.chainExists(id)).toBe(false);
   });
 
+  test('chain will fail deletion by fetchDelete if active', async () => {
+    expect.assertions(1);
+    const { id } = await service.createChainInstance({ ...options });
+    try {
+      await service.fetchDelete(id);
+    } catch (e) {
+      expect(e).toEqual(`Chain Could Not Be Deleted`);
+    }
+  });
+
   test('fetchDelete will throw error if attempt to delete active chain is made', async () => {
     expect.assertions(4);
     const { id } = await service.createChainInstance({
@@ -243,6 +235,18 @@ describe('chain removal', async () => {
       expect(e).toEqual('Chain Could Not Be Deleted');
       expect(await service.chainExists(id)).toBe(true);
     }
+  });
+
+  test('removeAllChains will remove all chains', async () => {
+    await service.createChainInstance({ ...options });
+    await service.createChainInstance({ ...options });
+
+    let chainList = await service.fetchChains();
+    expect(chainList.length).toEqual(2);
+
+    await service.removeAllChains();
+    chainList = await service.fetchChains();
+    expect(chainList.length).toEqual(0);
   });
 });
 
@@ -296,6 +300,7 @@ describe('snapshot examples', async () => {
     const targetSnapshot = snapshots.find(
       snapshot => snapshot.id === snapshotId
     );
+
     expect(snapshots.length > 0).toBe(true);
     expect(targetSnapshot.description).toBe(description);
   });


### PR DESCRIPTION
Removed `list_chains` method in favour of the rest endpoint `/chains/` which will list all active and inactive chains